### PR TITLE
Fix so with_server_config uses configured workspace path for knife rb

### DIFF
--- a/libraries/delivery_dsl.rb
+++ b/libraries/delivery_dsl.rb
@@ -248,7 +248,7 @@ module DeliverySugar
     # @return [DeliverySugar::ChefServer]
     #
     def chef_server
-      @delivery_chef_server ||= DeliverySugar::ChefServer.new
+      @delivery_chef_server ||= DeliverySugar::ChefServer.new(delivery_knife_rb)
     end
 
     #


### PR DESCRIPTION
Currently, `with_server_config` always uses `/var/opt/delivery/workspace` when looking for the knife.rb file, and does not pick up  `node['delivery']['workspace_path']`. This is because `DeliverySugar::ChefServer` initialization is using the DSL `delivery_knife_rb`. Within the context of a recipe, this will correctly evaluate. However, in the context of the ChefServer class there is no `node` method and so `change` raises an exception and `delivery_workspace` returns the default value.

The fix avoids this by passing in delivery_knife_rb evaluated in the context of the recipe. 