### PR TITLE
COOL-613: Add categories property to the supermarket upload method.

### DIFF
--- a/libraries/delivery_supermarket.rb
+++ b/libraries/delivery_supermarket.rb
@@ -34,9 +34,10 @@ class DeliverySupermarket < Chef::Resource
   # The knife.rb config file on disk
   property :config, String, default: lazy { delivery_knife_rb }
 
-  # The Supermarket site / user / key
+  # The Supermarket site / user / category / key
   property :site, String, default: 'https://supermarket.chef.io'
   property :user, String, default: 'delivery'
+  property :category, String, default: 'Other'
   property :key, String
 
   action :share do
@@ -69,7 +70,7 @@ class DeliverySupermarket < Chef::Resource
 
     # Share the cookbook to the Supermarket Site
     def share_cookbook_to_supermarket(options)
-      command = "knife supermarket share #{new_resource.cookbook} " \
+      command = "knife supermarket share #{new_resource.cookbook} \"#{new_resource.category}\" " \
                 "--cookbook-path #{cookbook_root} " \
                 "--config #{new_resource.config} " \
                 "--supermarket-site #{new_resource.site} " \

--- a/spec/unit/recipes/test_build_cookbook_deploy_spec.rb
+++ b/spec/unit/recipes/test_build_cookbook_deploy_spec.rb
@@ -36,6 +36,7 @@ describe 'test-build-cookbook::deploy' do
       .with_site('https://private-supermarket.example.com')
       .with_path('/path/to/cookbook/awesome')
       .with_cookbook('awesome')
+      .with_category('Applications')
       .with_config('/path/to/knife.rb')
   end
 end

--- a/test/fixtures/cookbooks/test-build-cookbook/recipes/deploy.rb
+++ b/test/fixtures/cookbooks/test-build-cookbook/recipes/deploy.rb
@@ -9,5 +9,6 @@ delivery_supermarket 'share_cookbook_to_custom_supermarket' do
   config '/path/to/knife.rb'
   user 'dummy'
   key 'SECRET'
+  category 'Applications'
   action :share
 end


### PR DESCRIPTION
When running Automate 0.5.1 with ChefDK 0.16.28 on a disconnected network I had an issue where when publishing a cookbook to the private supermarket publish would attempt to go the public supermarket unless a category was specified. This pull request fixes this issue by adding a property for categories to that library. This problem appears also be fixed by upgrading to ChefDK 0.18.30. In order to fully utilize this property I believe the delivery-truck cookbook will also need to be updated. 
