### PR TITLE
Add support for kitchen-dokken driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,29 @@ delivery_test_kitchen 'unit_create' do
 end
 ```
 
+#### Docker
+
+You can leverage the [kitchen-dokken](https://github.com/someara/kitchen-dokken) driver in your tests
+as well. This does not require the use of `delivery-secrets`. To enable `kitchen-dokken`, do the following to
+install Docker on all of your builders/runners:
+
+Add `depends 'docker', '~> 2.0'` to the `metadata.rb` of the build cookbook.
+Add the following code to the `default.rb` of the build cookbook:
+
+```ruby
+docker_service 'default' do
+  action [:create, :start]
+end
+
+group 'docker' do
+  action :modify
+  members 'dbuild'
+  append true
+end
+```
+
+
+
 ## Handling Secrets (ALPHA)
 This cookbook implements a rudimentary approach to handling secrets. This process
 is largely out of band from Chef Delivery for the time being.

--- a/libraries/delivery_test_kitchen.rb
+++ b/libraries/delivery_test_kitchen.rb
@@ -83,6 +83,8 @@ module DeliverySugar
       case @driver
       when 'ec2'
         prepare_kitchen_ec2
+      when 'dokken'
+        prepare_kitchen_dokken
       else
         fail "The test kitchen driver '#{@driver}' is not supported"
       end
@@ -142,6 +144,19 @@ aws_secret_access_key = #{secrets['ec2']['secret_key']}
         f.mode '0400'
       end
       file.run_action(:create)
+    end
+    #
+    # Specific requirements for dokken driver
+    # At this point, we might not really need to do very much because there
+    # isn't a lot of prep to do for this driver.
+    #
+
+    def prepare_kitchen_dokken
+      fail 'Kitchen YAML file not found' unless kitchen_yaml?
+
+      # Installing kitchen-dokken driver
+      chef_gem = Chef::Resource::ChefGem.new('kitchen-dokken', run_context)
+      chef_gem.run_action(:install)
     end
 
     # See if the kitchen YAML file exist in the repo


### PR DESCRIPTION
This commit enables the use of the `kitchen-dokken` driver for Test Kitchen in Workflow. It is a very minor change, as there are few items needed to enable it. The `kitchen-dokken` gem ships with ChefDK v0.16.11.

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>