### PR TITLE
Add delivery_inspec resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,37 @@ delivery_test_kitchen 'unit_create' do
 end
 ```
 
+## InSpec
+
+The resource `delivery_inspec` will enable your projects to run any [InSpec](https://inspec.io) tests in the cookbook against your nodes in Acceptance, Union, Rehearsal, or Delivered. Currently, we only support running tests against Linux or Windows nodes.
+
+### Prerequisites
+
+In order to enable this functionality, perform the following prerequisite steps:
+
+* Add the following items to the appropriate data bag as specified in the [Handling Secrets](#handling-secrets-alpha) section
+
+    **delivery-secrets <ent>-<org>-<project> encrypted data bag item**
+    ```json
+    {
+      "id": "<ent>-<org>-<project>",
+      "inspec": {
+        "ssh-user": "inspec",
+        "ssh-private-key": "<YOUR-PRIVATE-KEY-HERE",
+        "winrm-user": "inspec",
+        "winrm-password": "<YOUR-PASSWORD-HERE>"
+      }
+     }
+    ```
+    You can convert the private key content to a JSON-compatible string with a command like this:
+    ```
+    ruby -e 'require "json"; puts File.read("<path-to-inspec-private-key>").to_json'
+    ```
+
+* Ensure that the associated user for either `ssh-user` or `winrm-user` exists on the nodes to be tested, with either the public key added to `authorized_keys`(if Linux), or the password set (if Windows). The associated user must either have passwordless sudo, or be in the Administrators group (if Windows).
+
+Note that the `delivery_inspec` resource also supports "organization-level" data bag items, so the above item could also be set at `"id": "<ent>-<org>"`.
+
 ## Handling Secrets (ALPHA)
 This cookbook implements a rudimentary approach to handling secrets. This process
 is largely out of band from Chef Delivery for the time being.

--- a/libraries/delivery_inspec.rb
+++ b/libraries/delivery_inspec.rb
@@ -1,0 +1,147 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/mixin/shell_out'
+require_relative './delivery_dsl'
+require 'chef/dsl'
+
+module DeliverySugar
+  #
+  # This class is our interface to execute inspec tests
+  #
+  class Inspec
+    include Chef::DSL::Recipe
+    include DeliverySugar::DSL
+    include Chef::Mixin::ShellOut
+    attr_reader :repo_path, :os, :node
+    attr_accessor :run_context, :infra_node
+
+    #
+    # Create a new Inspec object
+    #
+    # @param repo_path [String]
+    #   The path to the project repository within the workspace
+    # @param run_context [Chef::RunContext]
+    #   The object that loads and tracks the context of the Chef run
+    # @param os [String]
+    #   The name of the OS of the infrastruture node
+    # @param infra_node [string]
+    #   The IP address of the infrastruture node
+    #
+    # @return [DeliverySugar::Inspec]
+    #
+    def initialize(repo_path, run_context, parameters = {})
+      @repo_path = repo_path
+      @run_context = run_context
+      @os = parameters[:os]
+      @infra_node = parameters[:infra_node]
+    end
+
+    #
+    # Run inspec action
+    #
+    def run_inspec
+      prepare_inspec
+      shell_out!(
+        "#{delivery_workspace_cache}/inspec.sh",
+        cwd: @repo_path,
+        live_stream: STDOUT
+      )
+    end
+
+    def prepare_inspec
+      case @os
+      when 'linux'
+        prepare_linux_inspec
+      when 'windows'
+        prepare_windows_inspec
+      else
+        fail "The operating system '#{@os}' is not supported"
+      end
+    end
+
+    #
+    # Create script for linux nodes
+    #
+    # rubocop:disable AbcSize
+    # rubocop:disable Metrics/MethodLength
+    def prepare_linux_inspec
+      # Load secrets from delivery-secrets data bag
+      secrets = get_project_secrets
+      fail 'Could not find secrets for inspec' \
+           ' in delivery-secrets data bag.' if secrets['inspec'].nil?
+      # Variables used for the linux inspec script
+      cache = delivery_workspace_cache
+      ssh_user = secrets['inspec']['ssh-user']
+      ssh_private_key_file = "#{cache}/.ssh/#{secrets['inspec']['ssh-user']}.pem"
+      ssh_hostname = @infra_node
+
+      # Create directory for SSH key
+      directory = Chef::Resource::Directory.new("#{cache}/.ssh", run_context)
+      directory.recursive true
+      directory.run_action(:create)
+
+      # Create private key
+      file = Chef::Resource::File.new(ssh_private_key_file, run_context).tap do |f|
+        f.content secrets['inspec']['ssh-private-key']
+        f.sensitive true
+        f.mode '0400'
+      end
+      file.run_action(:create)
+
+      # Create inspec script
+      file = Chef::Resource::File.new("#{cache}/inspec.sh", run_context).tap do |f|
+        f.content <<-EOF
+/opt/chefdk/embedded/bin/inspec exec #{node['delivery']['workspace']['repo']}/test/recipes/ -t ssh://#{ssh_user}@#{ssh_hostname} -i #{ssh_private_key_file}
+        EOF
+        f.sensitive true
+        f.mode '0750'
+      end
+      file.run_action(:create)
+    end
+
+    #
+    # Create script for Windows nodes
+    #
+    def prepare_windows_inspec
+      # Load secrets from delivery-secrets data bag
+      secrets = get_project_secrets
+      fail 'Could not find secrets for inspec' \
+           ' in delivery-secrets data bag.' if secrets['inspec'].nil?
+      # Variables used for the Windows inspec script
+      cache = delivery_workspace_cache
+      winrm_user = secrets['inspec']['winrm-user']
+      winrm_password = secrets['inspec']['winrm-password']
+      winrm_hostname = @infra_node
+
+      # Create inspec script
+      file = Chef::Resource::File.new("#{cache}/inspec.sh", run_context).tap do |f|
+        f.content <<-EOF
+/opt/chefdk/embedded/bin/inspec exec #{node['delivery']['workspace']['repo']}/test/recipes/ -t winrm://#{winrm_user}@#{winrm_hostname} --password '#{winrm_password}'
+        EOF
+        f.sensitive true
+        f.mode '0750'
+      end
+      file.run_action(:create)
+    end
+
+    # Returns the Chef::Node Object coming from the run_context
+    def node
+      run_context && run_context.node
+    end
+  end
+end

--- a/libraries/delivery_inspec_provider.rb
+++ b/libraries/delivery_inspec_provider.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class Provider
+    class DeliveryInspec < Chef::Provider
+      attr_reader :inspec
+
+      def whyrun_supported?
+        true
+      end
+
+      def load_current_resource
+        # There is no existing resource to evaluate, but we are required
+        # to override it.
+      end
+
+      def initialize(new_resource, run_context)
+        super
+
+        @inspec = DeliverySugar::Inspec.new(
+          new_resource.repo_path,
+          run_context,
+          os: new_resource.os,
+          infra_node: new_resource.infra_node
+        )
+      end
+
+      def action_test
+        converge_by 'Run inspec tests' do
+          @inspec.run_inspec
+          new_resource.updated_by_last_action(true)
+        end
+      end
+    end
+  end
+end

--- a/libraries/delivery_inspec_resource.rb
+++ b/libraries/delivery_inspec_resource.rb
@@ -1,0 +1,72 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+require_relative './delivery_dsl'
+
+class Chef
+  class Resource
+    class DeliveryInspec < Chef::Resource
+      include DeliverySugar::DSL
+      provides :delivery_inspec
+
+      def initialize(name, run_context = nil)
+        super
+        @resource_name = :delivery_inspec
+        @provider = Chef::Provider::DeliveryInspec
+
+        @repo_path = delivery_workspace_repo
+
+        @action = :test
+        @allowed_actions.push(:test)
+      end
+
+      #
+      # The fully-qualified path to the directory where the code is on disk
+      #
+      def repo_path(arg = nil)
+        set_or_return(
+          :repo_path,
+          arg,
+          kind_of: String
+        )
+      end
+
+      #
+      # The name of the OS of the infrastruture node
+      #
+      def os(arg = nil)
+        set_or_return(
+          :os,
+          arg,
+          kind_of: String
+        )
+      end
+
+      #
+      # The IP address of the infrastruture node
+      #
+      def infra_node(arg = nil)
+        set_or_return(
+          :infra_node,
+          arg,
+          kind_of: String, required: true
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds a new resource, `delivery_inspec`, which is used to run InSpec tests against infrastructure nodes.

This change also updates the `README` with documentation on how to use this functionality.

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>