### PR TITLE
Put slug format string into in-line code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,14 @@ scoped to the project root.
 
 #### `workflow_project_slug`
 Returns a unique string that can be used to identify the current project.
-**Format:** <ENTERPRISE>-<ORGANIZATION>-<PROJECT>
+
+**Format:** `<ENTERPRISE>-<ORGANIZATION>-<PROJECT>`
 
 #### `workflow_organization_slug`
 Returns a unique string that can be used to identify the organization associated
-with the current project. **Format:** <ENTERPRISE>-<ORGANIZATION>
+with the current project.
+
+**Format:** `<ENTERPRISE>-<ORGANIZATION>`
 
 ## Running against the Automate Chef Server
 Sometimes you need to perform actions in your build cookbook as though it was


### PR DESCRIPTION
Without the in-line code block the markdown does not render. Without
the newline the line wraps.

This PR fixes both of these issues.

Signed-off-by: Jerry Aldrich III <jerry@chef.io>