### PR TITLE
Add quorum attribute to delivery_push_job

### DIFF
--- a/libraries/delivery_push_job_provider.rb
+++ b/libraries/delivery_push_job_provider.rb
@@ -48,7 +48,8 @@ class Chef
           new_resource.chef_config_file,
           new_resource.command,
           new_resource.nodes,
-          new_resource.timeout
+          new_resource.timeout,
+          new_resource.quorum
         )
       end
 

--- a/libraries/delivery_push_job_resource.rb
+++ b/libraries/delivery_push_job_resource.rb
@@ -31,6 +31,7 @@ class Chef
         @command = name
         @timeout = 30 * 60 # 30 minutes
         @nodes = []
+        @quorum = nil
         @chef_config_file = delivery_knife_rb
 
         @provider = Chef::Provider::DeliveryPushJob
@@ -65,6 +66,7 @@ class Chef
       # The list of nodes you wish to execute the push job on.
       #
       def nodes(arg = nil)
+        @quorum ||= arg.length unless arg.nil?
         set_or_return(
           :nodes,
           arg,
@@ -78,6 +80,17 @@ class Chef
       def timeout(arg = nil)
         set_or_return(
           :timeout,
+          arg,
+          kind_of: Integer
+        )
+      end
+
+      #
+      # The number of nodes to reach quorum for the job
+      #
+      def quorum(arg = nil)
+        set_or_return(
+          :quorum,
           arg,
           kind_of: Integer
         )

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'delivery-team@chef.io'
 license 'Apache 2.0'
 description 'Syntatic sugars for Delivery build cookbooks'
 
-version '1.2.1'
+version '1.3.0'
 
 gem 'chef-vault'
 

--- a/spec/unit/delivery_push_job_provider_spec.rb
+++ b/spec/unit/delivery_push_job_provider_spec.rb
@@ -16,6 +16,7 @@ describe Chef::Provider::DeliveryPushJob do
   let(:chef_config_file) { '/workspace/.chef/knife.rb' }
   let(:command) { 'chef-client' }
   let(:timeout) { 10 }
+  let(:quorum) { 2 }
   let(:new_resource) { Chef::Resource::DeliveryPushJob.new(command, run_context) }
   let(:provider) { described_class.new(new_resource, run_context) }
 
@@ -32,7 +33,8 @@ describe Chef::Provider::DeliveryPushJob do
         chef_config_file,
         command,
         node_objects,
-        timeout
+        timeout,
+        quorum
       )
       described_class.new(new_resource, nil)
     end
@@ -46,7 +48,8 @@ describe Chef::Provider::DeliveryPushJob do
         new_resource.chef_config_file,
         new_resource.command,
         new_resource.nodes,
-        new_resource.timeout
+        new_resource.timeout,
+        new_resource.quorum
       ).and_return(push_job_client)
       allow(File).to receive(:exist?).with(chef_config_file).and_return(file_exist)
     end
@@ -73,6 +76,7 @@ describe Chef::Provider::DeliveryPushJob do
     end
 
     it 'dispatches push job and waits for completion' do
+      expect(new_resource).to receive(:quorum).and_return(2)
       allow(provider.push_job).to receive(:dispatch)
       allow(provider.push_job).to receive(:wait)
       expect(new_resource).to receive(:updated_by_last_action).with(true)

--- a/spec/unit/delivery_push_job_resource_spec.rb
+++ b/spec/unit/delivery_push_job_resource_spec.rb
@@ -18,6 +18,7 @@ describe Chef::Resource::DeliveryPushJob do
       expect(@resource.command).to eql('push_job')
       expect(@resource.timeout).to eql(30 * 60)
       expect(@resource.nodes).to eql([])
+      expect(@resource.quorum).to eql(nil)
     end
 
     it 'has a resource name of :delivery_push_job' do
@@ -68,6 +69,14 @@ describe Chef::Resource::DeliveryPushJob do
       @resource.nodes %w(a b)
       expect(@resource.nodes).to eql(%w(a b))
       expect { @resource.send(:nodes, 'a') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#quorum' do
+    it 'requires an Integer' do
+      @resource.quorum 2
+      expect(@resource.quorum).to eql(2)
+      expect { @resource.send(:quorum, '2') }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/unit/delivery_push_job_spec.rb
+++ b/spec/unit/delivery_push_job_spec.rb
@@ -11,6 +11,7 @@ describe DeliverySugar::PushJob do
   let(:nodes_body) { {} }
   let(:status) { 'voting' }
   let(:timeout) { 10 }
+  let(:quorum) { 1 }
   let(:chef_server) { double('ChefServer Object') }
 
   let(:job_uri) { 'http://localhost/organizations/ORG_NAME/pushy/jobs/ID' }
@@ -26,7 +27,7 @@ describe DeliverySugar::PushJob do
     }
   end
 
-  subject { described_class.new(chef_config_file, command, nodes, timeout) }
+  subject { described_class.new(chef_config_file, command, nodes, timeout, quorum) }
 
   before do
     allow(DeliverySugar::ChefServer).to receive(:new).with(chef_config_file)
@@ -38,6 +39,7 @@ describe DeliverySugar::PushJob do
       expect(subject.chef_server).to eql(chef_server)
       expect(subject.command).to eql(command)
       expect(subject.nodes).to eql(nodes)
+      expect(subject.quorum).to eql(quorum)
     end
 
     context 'when nodes are NOT an array of strings' do
@@ -59,6 +61,13 @@ describe DeliverySugar::PushJob do
         expect { subject }.not_to raise_error
       end
     end
+
+    context 'when quorum is not initialized' do
+      let(:quorum) { nil }
+      it 'should equal number of nodes' do
+        expect(subject.quorum).to eq(nodes.length)
+      end
+    end
   end
 
   describe '#dispatch' do
@@ -67,7 +76,8 @@ describe DeliverySugar::PushJob do
       {
         'command' => command,
         'nodes' => nodes,
-        'run_timeout' => timeout
+        'run_timeout' => timeout,
+        'quorum' => quorum
       }
     end
 


### PR DESCRIPTION
This pull adds a `quorum` attribute to `delivery_push_job` resource and associated classes. Quorum is the absolute number of nodes required in order for the job to run. This argument was not previously used when submitting jobs to the Chef server. I believe it had defaulted to 100%, the length of the `nodes` array. This behavior is preserved in this implementation.

This resource still assumes that every node must be successful in order for the job to be considered successful.

The next step after this would be to allow for quorum to be specified in `delivery-truck` as either a config.json or node attribute.