### PR TITLE
Add adjustable timeout for delivery_test_kitchen

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ scoped to the project root.
 
 #### `changed_dirs`
 Returns a list of all the directories modified in the current change. Optionally
-provide an integer to specify the desired directory depth. 
+provide an integer to specify the desired directory depth.
 
 #### `workflow_project_slug`
 Returns a unique string that can be used to identify the current project.
@@ -359,6 +359,17 @@ delivery_test_kitchen 'unit_create' do
   driver 'ec2'
   options '--log-level=debug'
   suite 'default'
+  action :create
+end
+```
+
+Trigger a kitchen create extending the timeout to 20 minutes
+
+```ruby
+delivery_test_kitchen 'unit_create' do
+  driver 'ec2'
+  suite 'default'
+  timeout 1200
   action :create
 end
 ```

--- a/libraries/delivery_test_kitchen.rb
+++ b/libraries/delivery_test_kitchen.rb
@@ -32,7 +32,7 @@ module DeliverySugar
     include DeliverySugar::DSL
     include Chef::Mixin::ShellOut
     attr_reader :driver, :repo_path, :environment, :options
-    attr_accessor :suite, :yaml, :run_context
+    attr_accessor :suite, :timeout, :yaml, :run_context
 
     #
     # Create a new TestKitchen object
@@ -56,6 +56,7 @@ module DeliverySugar
       @suite = parameters[:suite]
       @options = parameters[:options] || ''
       @environment = parameters[:environment] || {}
+      @timeout = parameters[:timeout]
     end
 
     #
@@ -67,7 +68,8 @@ module DeliverySugar
         "kitchen #{action} #{suite} #{@options}",
         cwd: @repo_path,
         env: @environment.merge!('KITCHEN_YAML' => kitchen_yaml_file),
-        live_stream: STDOUT
+        live_stream: STDOUT,
+        timeout: @timeout
       )
     end
 

--- a/libraries/delivery_test_kitchen_provider.rb
+++ b/libraries/delivery_test_kitchen_provider.rb
@@ -40,7 +40,8 @@ class Chef
           run_context,
           yaml: new_resource.yaml,
           options: new_resource.options,
-          suite: new_resource.suite
+          suite: new_resource.suite,
+          timeout: new_resource.timeout
         )
       end
 

--- a/libraries/delivery_test_kitchen_resource.rb
+++ b/libraries/delivery_test_kitchen_resource.rb
@@ -33,6 +33,7 @@ class Chef
         @yaml      = '.kitchen.yml'
         @suite     = 'all'
         @options   = ''
+        @timeout   = 3600
         @repo_path = delivery_workspace_repo
 
         @action    = :test
@@ -94,6 +95,17 @@ class Chef
           :options,
           arg,
           kind_of: String
+        )
+      end
+
+      #
+      # Adjustable timeout for Test Kitchen
+      #
+      def timeout(arg = nil)
+        set_or_return(
+          :timeout,
+          arg,
+          kind_of: Integer
         )
       end
     end

--- a/test/fixtures/cookbooks/test-build-cookbook/recipes/quality.rb
+++ b/test/fixtures/cookbooks/test-build-cookbook/recipes/quality.rb
@@ -17,3 +17,13 @@ delivery_test_kitchen 'quality_create' do
   options '--log-level=debug'
   action :create
 end
+
+#
+# Trigger a kitchen create extending the timeout to 20 minutes
+#
+delivery_test_kitchen 'quality_create_with_timeout' do
+  driver 'ec2'
+  suite 'default'
+  timeout 1200
+  action :create
+end


### PR DESCRIPTION
Implements #10 and #26. Allows a user to to set the timeout of the Test Kitchen run as a parameter to the delivery_test_kitchen resource.

Signed-off-by: John Byrne <johnb@chef.io>