### PR TITLE
Add ability to pass arbitrary environment variables via `envionment` attribute in delivery_test_kitchen block

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ More on that topic [here](examples/terraform/.delivery/build_cookbook/README_TER
 ## Test Kitchen
 
 The resource `delivery_test_kitchen` will enable your projects to use [Test Kitchen](http://kitchen.ci)
-in Delivery. Currently, we only support the [kitchen-ec2 driver](https://github.com/test-kitchen/kitchen-ec2) and  [kitchen-azurerm](https://github.com/pendrica/kitchen-azurerm) drivers.
+in Delivery. Currently, we support: [kitchen-ec2 driver](https://github.com/test-kitchen/kitchen-ec2) and [kitchen-azurerm](https://github.com/pendrica/kitchen-azurerm), [kitchen-dokken](https://github.com/someara/kitchen-dokken), and [chef-provisioning-vsphere](https://github.com/chef-partners/chef-provisioning-vsphere) drivers.
 
 ### Prerequisites
 
@@ -425,6 +425,26 @@ delivery_test_kitchen 'unit_create' do
   timeout 1200
   action :create
 end
+```
+
+Trigger a kitchen create injecting arbitrary environment variables
+
+```ruby
+delivery_test_kitchen 'unit_create' do
+  driver 'ec2'
+  suite 'default'
+  environment('TK_EC2_REGION' => 'us-west-2', 'TK_MACHINE_SIZE' => 't2.micro')
+  action :test
+end
+```
+
+This assumes your `.kitchen.yml` is leveraging environment variables e.g.:
+
+```ruby
+driver:
+  name: ec2
+  region: <%= ENV['TK_EC2_REGION'] %>
+  instance_type: <%= ENV['TK_INSTANCE_TYPE'] %>
 ```
 
 ## InSpec

--- a/libraries/delivery_test_kitchen_provider.rb
+++ b/libraries/delivery_test_kitchen_provider.rb
@@ -41,7 +41,8 @@ class Chef
           yaml: new_resource.yaml,
           options: new_resource.options,
           suite: new_resource.suite,
-          timeout: new_resource.timeout
+          timeout: new_resource.timeout,
+          environment: new_resource.environment
         )
       end
 

--- a/libraries/delivery_test_kitchen_resource.rb
+++ b/libraries/delivery_test_kitchen_resource.rb
@@ -35,6 +35,7 @@ class Chef
         @options   = ''
         @timeout   = 3600
         @repo_path = delivery_workspace_repo
+        @environment = {}
 
         @timeout   = 3600
         @action    = :test
@@ -52,6 +53,17 @@ class Chef
           arg,
           kind_of: String,
           required: true
+        )
+      end
+
+      #
+      # The test kitchen shell environemnt variables
+      #
+      def environment(arg = nil)
+        set_or_return(
+          :environment,
+          arg,
+          kind_of: Hash
         )
       end
 

--- a/spec/unit/delivery_test_kitchen_resource_spec.rb
+++ b/spec/unit/delivery_test_kitchen_resource_spec.rb
@@ -16,6 +16,7 @@ describe Chef::Resource::DeliveryTestKitchen do
       expect(@resource.yaml).to eql('.kitchen.yml')
       expect(@resource.suite).to eql('all')
       expect(@resource.repo_path).to eql('/workspace/path/to/phase/repo')
+      expect(@resource.environment).to eql({})
     end
 
     it 'has a resource name of :delivery_test_kitchen' do
@@ -33,6 +34,14 @@ describe Chef::Resource::DeliveryTestKitchen do
     it 'is required' do
       resource = described_class.new('unit_test')
       expect { resource.driver }.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+  end
+
+  describe '#environment' do
+    it 'must be a hash' do
+      @resource.environemnt {}
+      expect(@resource.environment).to eql({})
+      expect { @resource.send(:environment, ['r']) }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
Hello,

This PR is in reference to #38 .  

Basically, this is the monkey-patch that I'm using to enable to me to pass Environment variables to test kitchen runs/our `.kitchen.yml` .  The framework was already there, and everywhere it seems like it was assumed that env vars might be passed in, but the facilities to actually pass env vars was not there.

This PR enables the ability to pass environment settings a la:

```ruby
env_vars = {
  'TK_EC2_REGION' => 'us-west-1'
  'foo' => 'bar',
  'CODE' => '0451',
  ...
}

  delivery_test_kitchen "kitchen_run" do
    environment env_vars
  end
```

If I'm being totally honest, this PR exists mostly because it reduces the monkey patching I have to do... but also if I'm trying to pass env vars, who else has a similar use case?

Thanks,
- Q
